### PR TITLE
chore: Add 'CATEGORY' meta to create_udf

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,16 @@
+from eva.server.db_api import connect
+import nest_asyncio
+nest_asyncio.apply()
+
+# Get Cursor
+connection = connect(host = '0.0.0.0', port = 5432) # hostname, port of the server where EVADB is running
+cursor = connection.cursor()
+
+# Drop a UDF
+cursor.execute("DROP UDF IF EXISTS FastRCNNObjectDetector")
+response = cursor.fetch_all()
+
+# Re-Create the UDF
+cmd = "CREATE UDF IF NOT EXISTS FastRCNNObjectDetector INPUT  (frame NDARRAY UINT8(3, ANYDIM, ANYDIM)) OUTPUT (labels NDARRAY STR(ANYDIM), bboxes NDARRAY FLOAT32(ANYDIM, 4), scores NDARRAY FLOAT32(ANYDIM)) TYPE Classification CATEGORY 'VehicleCount' IMPL 'eva/udfs/fastrcnn_object_detector.py';"
+cursor.execute(cmd)
+response = cursor.fetch_all()

--- a/eva/catalog/catalog_manager.py
+++ b/eva/catalog/catalog_manager.py
@@ -205,6 +205,7 @@ class CatalogManager(object):
         name: str,
         impl_file_path: str,
         type: str,
+        category: str,
         udf_io_list: List[UdfIO],
     ) -> UdfMetadata:
         """Creates an udf metadata object and udf_io objects and persists them
@@ -216,13 +217,16 @@ class CatalogManager(object):
                                  relative to eva/udf
             type(str): what kind of udf operator like classification,
                                                         detection etc
+            category(str): what category of udf operator like VehicleCount,
+                                                    ContainsCars, etc
             udf_io_list(List[UdfIO]): input/output info of this udf
 
         Returns:
             The persisted UdfMetadata object with the id field populated.
         """
 
-        metadata = self._udf_service.create_udf(name, impl_file_path, type)
+        print("catalog_manager.py::create_udf --> self._udf_service.create_udf")
+        metadata = self._udf_service.create_udf(name, impl_file_path, type, category)
         for udf_io in udf_io_list:
             udf_io.udf_id = metadata.id
         self._udf_io_service.add_udf_io(udf_io_list)

--- a/eva/catalog/models/udf.py
+++ b/eva/catalog/models/udf.py
@@ -29,10 +29,12 @@ class UdfMetadata(BaseModel):
         "UdfIO", back_populates="_udf", cascade="all, delete, delete-orphan"
     )
 
-    def __init__(self, name: str, impl_file_path: str, type: str):
+    def __init__(self, name: str, impl_file_path: str, type: str, category: str):
         self._name = name
         self._impl_file_path = impl_file_path
         self._type = type
+        print("udf.py::UdfMetadata::__init__")
+        self._category = category
 
     @property
     def id(self):
@@ -50,6 +52,11 @@ class UdfMetadata(BaseModel):
     def type(self):
         return self._type
 
+    @property
+    def category(self):
+        print("udf.py::UdfMetadata::category")
+        return self._category
+
     def display_format(self):
         inputs = []
         outputs = []
@@ -60,17 +67,19 @@ class UdfMetadata(BaseModel):
                 inputs.append(col_string)
             else:
                 outputs.append(col_string)
+        print("udf.py::UdfMetadata::display_format")
         return {
             "name": self.name,
             "inputs": inputs,
             "outputs": outputs,
             "type": self.type,
+            "category": self.category,
             "impl": self.impl_file_path,
         }
 
     def __str__(self):
-        udf_str = "udf: ({}, {}, {})\n".format(
-            self.name, self.impl_file_path, self.type
+        udf_str = "udf: ({}, {}, {} {})\n".format(
+            self.name, self.impl_file_path, self.type, self.catgory
         )
         return udf_str
 
@@ -80,7 +89,8 @@ class UdfMetadata(BaseModel):
             and self.impl_file_path == other.impl_file_path
             and self.name == other.name
             and self.type == other.type
+            and self.category == other.category
         )
 
     def __hash__(self) -> int:
-        return hash((self.id, self.name, self.impl_file_path, self.type))
+        return hash((self.id, self.name, self.impl_file_path, self.type, self.category))

--- a/eva/catalog/services/udf_service.py
+++ b/eva/catalog/services/udf_service.py
@@ -23,18 +23,20 @@ class UdfService(BaseService):
     def __init__(self):
         super().__init__(UdfMetadata)
 
-    def create_udf(self, name: str, impl_path: str, type: str) -> UdfMetadata:
+    def create_udf(self, name: str, impl_path: str, type: str, category: str) -> UdfMetadata:
         """Creates a new udf entry
 
         Arguments:
             name (str): name of the udf
             impl_path (str): path to the udf implementation relative to eva/udf
             type (str): udf operator kind, classification or detection or etc
+            category (str) : udf operator category: VehicleCount, ContainsCars, etc
 
         Returns:
             UdfMetadata: Returns the new entry created
         """
-        metadata = self.model(name, impl_path, type)
+        print("udf_service.py::create_udf --> self.model")
+        metadata = self.model(name, impl_path, type, category)
         metadata = metadata.save()
         return metadata
 

--- a/eva/executor/create_udf_executor.py
+++ b/eva/executor/create_udf_executor.py
@@ -60,9 +60,9 @@ class CreateUDFExecutor(AbstractExecutor):
             )
             logger.error(err_msg)
             raise RuntimeError(err_msg)
+        print("create_udf_executor.py::exec --> catalog_manager.create_udf")
         catalog_manager.create_udf(
-            self.node.name, impl_path, self.node.udf_type, io_list
-        )
+            self.node.name, impl_path, self.node.udf_type, self.node.udf_category, io_list)
         yield Batch(
             pd.DataFrame([f"UDF {self.node.name} successfully added to the database."])
         )

--- a/eva/parser/evaql/evaql_lexer.g4
+++ b/eva/parser/evaql/evaql_lexer.g4
@@ -156,6 +156,7 @@ UDF:						                'UDF';
 INPUT:                          'INPUT';
 OUTPUT:                         'OUTPUT';
 TYPE:                           'TYPE';
+CATEGORY:                       'CATEGORY';
 IMPL:                           'IMPL';
 
 // MATERIALIZED

--- a/eva/parser/evaql/evaql_parser.g4
+++ b/eva/parser/evaql/evaql_parser.g4
@@ -71,10 +71,11 @@ createUdf
     : CREATE UDF
       ifNotExists?
       udfName
-      INPUT  createDefinitions
-      OUTPUT createDefinitions
-      TYPE   udfType
-      IMPL   udfImpl
+      INPUT    createDefinitions
+      OUTPUT   createDefinitions
+      TYPE     udfType
+      CATEGORY udfCategory
+      IMPL     udfImpl
     ;
 
 // Create Materialized View
@@ -93,6 +94,10 @@ udfName
 
 udfType
     : uid
+    ;
+
+udfCategory
+    : stringLiteral
     ;
 
 udfImpl

--- a/eva/planner/create_udf_plan.py
+++ b/eva/planner/create_udf_plan.py
@@ -39,7 +39,9 @@ class CreateUDFPlan(AbstractPlan):
             This file should be placed in the data directory and
             the path provided should be relative to the eva dir.
         udf_type: str
-            udf type. it ca be object detection, classification etc.
+            udf type. it can be object detection, classification etc.
+        udf_category: str
+            udf category. it can be VehicleCount, VehicleCount etc.
     """
 
     def __init__(
@@ -50,6 +52,7 @@ class CreateUDFPlan(AbstractPlan):
         outputs: List[UdfIO],
         impl_file_path: Path,
         udf_type: str = None,
+        udf_category: str = None
     ):
         super().__init__(PlanOprType.CREATE_UDF)
         self._name = name
@@ -58,6 +61,8 @@ class CreateUDFPlan(AbstractPlan):
         self._outputs = outputs
         self._impl_path = impl_file_path
         self._udf_type = udf_type
+        self._udf_category = udf_category
+        print("create_udf_plan.py::CreateUDFPlan::__init__")
 
     @property
     def name(self):
@@ -83,6 +88,10 @@ class CreateUDFPlan(AbstractPlan):
     def udf_type(self):
         return self._udf_type
 
+    @property
+    def udf_category(self):
+        return self._udf_category
+
     def __hash__(self) -> int:
         return hash(
             (
@@ -92,5 +101,6 @@ class CreateUDFPlan(AbstractPlan):
                 tuple(self.outputs),
                 self.impl_path,
                 self.udf_type,
+                self.udf_category,
             )
         )

--- a/eva/udfs/udf_bootstrap_queries.py
+++ b/eva/udfs/udf_bootstrap_queries.py
@@ -23,6 +23,7 @@ DummyObjectDetector_udf_query = """CREATE UDF IF NOT EXISTS DummyObjectDetector
                   INPUT  (Frame_Array NDARRAY INT8(3, ANYDIM, ANYDIM))
                   OUTPUT (label NDARRAY STR(1))
                   TYPE  Classification
+                  CATEGORY "VehicleCount"
                   IMPL  '{}/../test/util.py';
         """.format(
     EVA_INSTALLATION_DIR
@@ -33,6 +34,7 @@ DummyMultiObjectDetector_udf_query = """CREATE UDF
                   INPUT  (Frame_Array NDARRAY INT8(3, ANYDIM, ANYDIM))
                   OUTPUT (labels NDARRAY STR(2))
                   TYPE  Classification
+                  CATEGORY "VehicleCount"
                   IMPL  '{}/../test/util.py';
         """.format(
     EVA_INSTALLATION_DIR
@@ -43,6 +45,7 @@ ArrayCount_udf_query = """CREATE UDF
             INPUT (Input_Array NDARRAY ANYTYPE, Search_Key ANYTYPE)
             OUTPUT (key_count INTEGER)
             TYPE NdarrayUDF
+            CATEGORY "VehicleCount"
             IMPL "{}/udfs/{}/array_count.py";
         """.format(
     EVA_INSTALLATION_DIR, NDARRAY_DIR
@@ -53,6 +56,7 @@ Crop_udf_query = """CREATE UDF IF NOT EXISTS Crop
                         bboxes NDARRAY FLOAT32(ANYDIM, 4))
                 OUTPUT (Cropped_Frame_Array NDARRAY UINT8(3, ANYDIM, ANYDIM))
                 TYPE  NdarrayUDF
+                CATEGORY "VehicleCount"
                 IMPL  "{}/udfs/{}/crop.py";
         """.format(
     EVA_INSTALLATION_DIR, NDARRAY_DIR
@@ -62,6 +66,7 @@ Unnest_udf_query = """CREATE UDF IF NOT EXISTS Unnest
                 INPUT  (inp NDARRAY ANYTYPE)
                 OUTPUT (out ANYTYPE)
                 TYPE  NdarrayUDF
+                CATEGORY "VehicleCount"
                 IMPL  "{}/udfs/{}/unnest.py";
         """.format(
     EVA_INSTALLATION_DIR, NDARRAY_DIR
@@ -71,7 +76,8 @@ Fastrcnn_udf_query = """CREATE UDF IF NOT EXISTS FastRCNNObjectDetector
       INPUT  (Frame_Array NDARRAY UINT8(3, ANYDIM, ANYDIM))
       OUTPUT (labels NDARRAY STR(ANYDIM), bboxes NDARRAY FLOAT32(ANYDIM, 4),
                 scores NDARRAY FLOAT32(ANYDIM))
-      TYPE  Classification
+      TYPE     Classification
+      CATEGORY "VehicleCount"
       IMPL  '{}/udfs/fastrcnn_object_detector.py';
       """.format(
     EVA_INSTALLATION_DIR


### PR DESCRIPTION
Code execution and my understanding of flow:
```
PlanExecutor.plan_executor._build_execution_tree
    --> About this call:
        --> Builds the execution tree from plan tree
        --> For each type of operation plan type, it calls the exec function from corresponding class
        --> For the current use case we are interested in the exec function of CreateUDFExecutor
    --> create_udf_executor.CreateUDFExecutor.exec()
        --> About this call:
            --> Instantiates an object of CatalogManager
            --> Checks if the UDF already exists
            --> Validates the UDF Class by instantiating it
                --> TODO: Can we explore this location to profile
                --> TODO: This can be blocking to get things rolling
        --> catalog_manager.catalog_manager.create_udf()
            ---> About this call
                --> Creates an udf metadata object and udf_io objects and persists them in database
            --> metadata = udf_service._udf_service.create_udf
                --> return self.model
                --> udf.UdfMetadata.__init__
```